### PR TITLE
fix logout link on aps tab

### DIFF
--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -5,6 +5,7 @@ class AppsController < ApplicationController
   # GET /apps
   # GET /apps.json
   def index
+    @current_user = User.find_by_id(session[:user_id])
     @apps = App.all
     respond_to do |format|
       format.json { render :json => @apps.featured }


### PR DESCRIPTION
Currently the app is checking if a logged-in user exists using `session[:user_id]` (check `app/views/layouts/_nav_header.html.haml`). This means we need to set `@current_user` for each controller method, and this is being done in `application_controller#logged_in?`. Unfortunately, since we designed the app so that 'apps' page do not require a user login, the login function is being skipped only for `apps_controller#index`. So I manually added a line so that the app finds a user with user id from `session[:user_id]`. If user exists it will set `@current_user` non-nil value, displaying logout link in the navigation bar, otherwise it will set `@current_user` nil, displaying no logout link in the nav bar.