### PR TITLE
[feat] add cucumber step definition helper

### DIFF
--- a/features/step_definitions/helper.rb
+++ b/features/step_definitions/helper.rb
@@ -1,0 +1,8 @@
+When /^dump current page info$/ do
+	p current_url
+	p page.body
+end
+
+When /^PENDING:/ do
+	pending
+end


### PR DESCRIPTION
Add cucumber step definition helper:
- PENDING: lets you have a pending feature step. Have ALL steps be pending, and remove it while implementing
- dump: when you get cucumber error, and you don't know why, this helper prints out current url and body of the html file. To use this helper method simple add 'When dump' at the line before the error.