### PR TITLE
change sid and type column order

### DIFF
--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -17,6 +17,6 @@
         %td= user.name
         %td= mail_to user.email
         %td= link_to(user.github_uid, "https://github.com/#{user.github_uid}") unless user.github_uid.blank?
-        %td= user.sid
         %td= user.type_user
+        %td= user.sid
         %td= link_to 'Edit', edit_user_path(user), :class => 'btn btn-primary'


### PR DESCRIPTION
Changed User index page so order of type and sid info matches the order in the table header.