### PR TITLE
[cucumber] add cucumber scenarios for different comment tyeps

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,13 @@
+exclude_paths:
+- "tests/"
+- "spec/"
+- "**/vendor/"
+- config/
+- db/
+- dist/
+- features/
+- **/node_modules/
+- script/
+- **/*.d.ts
+- **/bootstrap.js
+- **/initializers/

--- a/features/comment_types.feature
+++ b/features/comment_types.feature
@@ -1,0 +1,56 @@
+@wip
+Feature: Users can choose a type of comment on app
+
+	AS a staff that manages the matching between a project and customers
+	SO THAT I can easily keep track of an app's progress of customer matching
+	I WANT the app page have different comment types not only for general comments, but also for contact progress
+
+Background:
+    Given the following apps exist:
+		| name  | description | org_id | status  |
+		| app1  | test        | 1      | pending |
+		| app2  | test        | 1      | pending |
+		| app3  | test        | 1      | pending |
+
+	And I am logged in
+	And I follow "app1"
+
+Scenario: there are different comment types available
+	Then I should see "Contact Status"
+	And I should see "App Functionality"
+	And I should see "General"
+
+Scenario: User can edit and choose different comment types
+	Given I fill in "Write a comment..." with "This App is AWESOME!"
+	And I press "Post"
+	When I follow "Edit"
+	And I choose "App Functionality"
+	And I press "Edit"
+	And I uncheck all comment types
+	And I check "App Functionality"
+	Then I should see "This App is AWESOME!"
+
+Scenario: User can group comments by type
+	Given the following comments exist:
+		| user 			  | body 						| comment_type 		|
+		| esaas_developer | add search feature			| App Functionality |
+		| armando_fox	  | Contacted AFX Dance Manager | Contact Status 	|
+		| adnanhemani	  | I'm still a single!			| General 			|
+	When I uncheck all comment types
+	Then I should not see any comments
+	When I check "App Functionality" within "#select_comment_type"
+	Then I should see "add search feature"
+
+	When I uncheck all comment types
+	When I check "Contact Status" within "#select_comment_type"
+	Then I should see "Contacted AFX Dance Manager"
+
+	When I uncheck all comment types
+	When I check "General" within "#select_comment_type"
+	Then I should see "I'm still a single!"
+
+	When I uncheck all comment types
+	When I check "App Functionality" within "#select_comment_type"
+	And I check "General" within "#select_comment_type"
+	Then I should see "add search feature"
+	And I should see "I'm still a single!"

--- a/features/comment_types.feature
+++ b/features/comment_types.feature
@@ -15,11 +15,13 @@ Background:
 	And I am logged in
 	And I follow "app1"
 
+# Story ID: 152689457
 Scenario: there are different comment types available
 	Then I should see "Contact Status"
 	And I should see "App Functionality"
 	And I should see "General"
 
+# Story ID: 152689457
 Scenario: User can edit and choose different comment types
 	Given I fill in "Write a comment..." with "This App is AWESOME!"
 	And I press "Post"
@@ -30,6 +32,7 @@ Scenario: User can edit and choose different comment types
 	And I check "App Functionality"
 	Then I should see "This App is AWESOME!"
 
+# Story ID: 152689457
 Scenario: User can group comments by type
 	Given the following comments exist:
 		| user 			  | body 						| comment_type 		|

--- a/features/step_definitions/comment_type_steps.rb
+++ b/features/step_definitions/comment_type_steps.rb
@@ -1,0 +1,7 @@
+And /^I uncheck all comment types$/ do
+	pending
+end
+
+Given /^the following comments exist:$/ do |table|
+	pending
+end


### PR DESCRIPTION
add cucumber scenarios that checks existence of different comment
types, comment types as an attribute of a comment (edit), and checks if
comments can be grouped by comment type. Also added code climate config
to check if excluding pattern can be applied locally.