### PR TITLE
Fixing the edit page of customer feedback

### DIFF
--- a/app/controllers/iterations_controller.rb
+++ b/app/controllers/iterations_controller.rb
@@ -14,7 +14,7 @@ class IterationsController < ApplicationController
   def edit
     @feedback = JSON.parse(@iteration.customer_feedback)
     rescue (Exception)
-      redirect_to engagement_iterations_path, alert: "Customer Feedback does not have editable format." 
+      @feedback = Hash.new
   end
 
   def create

--- a/app/models/iteration.rb
+++ b/app/models/iteration.rb
@@ -46,4 +46,12 @@ class Iteration < ActiveRecord::Base
   def self.rating_to_score(rating)
   	self.ratings[rating]
   end
+
+  def self.rating_options
+    ['Strongly agree', 'Mostly agree', 'Neither agree nor disagree', 'Mostly disagree', 'Strongly disagree']
+  end
+
+  def self.duration_options
+    ['15 min', '30 min', '45 min', '1 hour', '1 hour 15 min', '1 hour 30 min', 'Longer than 1 hour 30 min']
+  end
 end

--- a/app/views/iterations/edit.html.haml
+++ b/app/views/iterations/edit.html.haml
@@ -1,14 +1,58 @@
 %h1 Edit Customer Feedback
 
 = form_tag engagement_iteration_path(@engagement, @iteration), :method => 'put' do
-    = label :iteration, "End date:"
+    = label :iteration, "End date: "
     = date_select :iteration, :end_date, :default => @iteration.end_date
     %br
 
-    - @feedback.each do |k,v|
-        = label :customer_feedback, k + ':'
-        = text_field :customer_feedback , k.to_sym, :value => v
-        %br
+    = label_tag :duration, 'Duration: '
+    = select :customer_feedback, :duration, Iteration.duration_options, :selected => @feedback["duration"]
+    %br
+
+    = label_tag :demeanor, 'Demeanor: '
+    = select :customer_feedback, :demeanor, Iteration.rating_options, :selected => @feedback["demeanor"]
+    %br
+
+    = label_tag :engaged, 'Engaged: '
+    = select :customer_feedback, :engaged, Iteration.rating_options, :selected => @feedback["engaged"]
+    %br
+
+    = label :customer_feedback, "Engagement Comments: "
+    = text_field :customer_feedback, :engaged_text, :value => @feedback["engaged_text"]
+    %br
+
+    = label_tag :communication, 'Communication: '
+    = select :customer_feedback, :communication, Iteration.rating_options, :selected => @feedback["communication"]
+    %br
+
+    = label :customer_feedback, "Communication Comments: "
+    = text_field :customer_feedback, :communication_text, :value => @feedback["communication_text"]
+    %br
+
+    = label_tag :understanding, 'Understanding: '
+    = select :customer_feedback, :understanding, Iteration.rating_options, :selected => @feedback["understanding"]
+    %br
+
+    = label :customer_feedback, "Understanding Comments: "
+    = text_field :customer_feedback, :understanding_text, :value => @feedback["understanding_text"]
+    %br
+
+    = label_tag :effectiveness, 'Effectiveness: '
+    = select :customer_feedback, :effectiveness, Iteration.rating_options, :selected => @feedback["effectiveness"]
+    %br
+
+    = label :customer_feedback, "Effectiveness Comments: "
+    = text_field :customer_feedback, :effectiveness_text, :value => @feedback["effectiveness_text"]
+    %br
+
+    = label_tag :satisfied, 'Satisfied: '
+    = select :customer_feedback, :satisfied, Iteration.rating_options, :selected => @feedback["satisfied"]
+    %br
+
+    = label :customer_feedback, "Satisfied Comments: "
+    = text_field :customer_feedback, :satisfied_text, :value => @feedback["satisfied_text"]
+    %br
+
     %br
     = submit_tag 'Save Changes'
     

--- a/features/step_definitions/create_steps.rb
+++ b/features/step_definitions/create_steps.rb
@@ -45,6 +45,8 @@ When /^I fill in the "(.*)" fields as follows:$/ do |fieldset, table|
       steps %Q{When I #{$1}check "#{t[:field]}"}
     when /^choose "(.*)"$/
       steps %Q{When I choose "#{$1}" for "#{t[:field]}"}
+    when /^select "(.*)"$/
+      steps %Q{When I select "#{$1}" for "#{t[:field]}"}
     else
       if "#{t[:field]}" == "Type of user"
         steps %Q{I fill in the following:

--- a/features/view_feedback.feature
+++ b/features/view_feedback.feature
@@ -33,15 +33,15 @@ Scenario: When I'm on the edit page, I see the edit form
     And I should see "Duration:"
     And I should see "Demeanor:"
     And I should see "Engaged:"
-    And I should see "Engaged text:"
+    And I should see "Engagement comments:"
     And I should see "Communication:"
-    And I should see "Communication text:"
+    And I should see "Communication comments:"
     And I should see "Understanding:"
-    And I should see "Understanding text:"
+    And I should see "Understanding comments:"
     And I should see "Effectiveness:"
-    And I should see "Effectiveness text:"
+    And I should see "Effectiveness comments:"
     And I should see "Satisfied:"
-    And I should see "Satisfied text:"
+    And I should see "Satisfied comments:"
 
 # Story ID: 152298649
 Scenario: If feedback already submiited by form, I can edit the feedback and see the changes
@@ -49,48 +49,58 @@ Scenario: If feedback already submiited by form, I can edit the feedback and see
     Then the field "duration" should be filled with "15 min"
     And the field "satisfied_text" should be filled with "I am satisfied"
     When I fill in the "Feedback" fields as follows:
-        | field                             | value              |
-        | customer_feedback[duration]       | 30 min             |
+        | field                              | value              |
+        | customer_feedback[duration]        | select "30 min"    |
         | customer_feedback[satisfied_text]  | I'm super happy!!! |
     And I press "Save Changes"
+    Then I should see "Iteration was successfully updated."
     When I am on the edit engagement iteration page for engagement id "1" and iteration id "2"
     Then the field "duration" should be filled with "30 min"
     And the field "satisfied_text" should be filled with "I'm super happy!!!"
 
 # Story ID: 152298649
-Scenario: I can leave a field blank and it may still be saved
+Scenario: I can leave a comment field blank and it may still be saved
     Given I am on the edit engagement iteration page for engagement id "1" and iteration id "2"
     When I fill in the "Feedback" fields as follows:
         | field                             | value              |
-        | customer_feedback[duration]       |                    |
-        | customer_feedback[satisfied_text]  | I'm super happy!!! |
+        | customer_feedback[duration]       | select "45 min"    |
+        | customer_feedback[satisfied_text] |                    |
     And I press "Save Changes"
+    Then I should see "Iteration was successfully updated."
     When I am on the edit engagement iteration page for engagement id "1" and iteration id "2"
-    Then the field "duration" should be filled with ""
-    And the field "satisfied_text" should be filled with "I'm super happy!!!"
+    Then the field "duration" should be filled with "45 min"
+    And the field "satisfied_text" should be filled with ""
 
 # Story ID: 152689630
-@wip
 Scenario: If feedback hasn't been submitted by form yet and is blank, a user can manually add in feedback
-    Given I try to visit the edit engagement iteration page for engagement id "1" and iteration id "1"
+Given I am on the edit engagement iteration page for engagement id "1" and iteration id "1"
     And I fill in the "Feedback" fields as follows:
-        | field                 | value                              |
-        | duration              | choose "1 hour"                    |
-        | demeanor              | choose "Mostly agree"              | 
-        | engaged               | choose "Mostly agree"              | 
-        | engaged_text          | They were engaged                  | 
-        | communication         | choose "Mostly agree"              | 
-        | communication_text    | They communicated well             | 
-        | understanding         | choose "Mostly agree"              | 
-        | understanding_text    | They understood well               | 
-        | effectiveness         | choose "Mostly agree"              | 
-        | effectiveness_text    | They were effective                | 
-        | satisfied             | choose "Mostly agree"              |
-        | satisfied_text        | I am satisfied                     |
-    And I press "Submit"
+        | field                                  | value                              |
+        | customer_feedback[duration]            | select "1 hour"                    |
+        | customer_feedback[demeanor]            | select "Mostly agree"              |
+        | customer_feedback[engaged]             | select "Strongly agree"            |
+        | customer_feedback[engaged_text]        | They were engaged                  |
+        | customer_feedback[communication]       | select "Neither agree nor disagree"|
+        | customer_feedback[communication_text]  | They communicated well             |
+        | customer_feedback[understanding]       | select "Mostly disagree"           |
+        | customer_feedback[understanding_text]  | They understood well               |
+        | customer_feedback[effectiveness]       | select "Strongly disagree"         |
+        | customer_feedback[effectiveness_text]  | They were effective                |
+        | customer_feedback[satisfied]           | select "Mostly agree"              |
+        | customer_feedback[satisfied_text]      | I am satisfied                     |
+    And I press "Save Changes"
+    Then I should see "Iteration was successfully updated."
+    When I am on the edit engagement iteration page for engagement id "1" and iteration id "1"
+    Then the field "duration" should be filled with "1 hour"
+    And the field "demeanor" should be filled with "Mostly agree"
+    And the field "engaged" should be filled with "Strongly agree"
+    And the field "engaged_text" should be filled with "They were engaged"
+    And the field "communication" should be filled with "Neither agree nor disagree"
+    And the field "communication_text" should be filled with "They communicated well"
+    And the field "understanding" should be filled with "Mostly disagree"
+    And the field "understanding_text" should be filled with "They understood well"
+    And the field "effectiveness" should be filled with "Strongly disagree"
+    And the field "effectiveness_text" should be filled with "They were effective"
+    And the field "satisfied" should be filled with "Mostly agree"
     And the field "satisfied_text" should be filled with "I am satisfied"
-
-
-
-
 


### PR DESCRIPTION
I changed edit form to allow select, and to allow users to edit feedback even if some or all fields are blank. I also updated corresponding cucumber tests