### PR TITLE
[refactor] clean code smells

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,13 +1,13 @@
 ---
 engines:
   brakeman:
-    enabled: true
+    enabled: false
   bundler-audit:
-    enabled: true
+    enabled: false
   csslint:
-    enabled: true
+    enabled: false
   coffeelint:
-    enabled: true
+    enabled: false
   duplication:
     enabled: true
     config:
@@ -17,9 +17,9 @@ engines:
       - python
       - php
   eslint:
-    enabled: true
+    enabled: false
   fixme:
-    enabled: true
+    enabled: false
   rubocop:
     enabled: true
 ratings:
@@ -44,4 +44,11 @@ exclude_paths:
 - features/
 - spec/
 - vendor/
-- bootstrap
+- "**bootstrap**"
+- bin/
+- coverage/
+- lib/
+- tmp/
+- log/
+- public/
+- iterations/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,27 @@
+language: ruby
+rvm:
+  - 2.3.1
+
+bundler_args: --without production
+
 env:
   global:
     - CC_TEST_REPORTER_ID=82fff89ba0da7030cf339a100c267baf4fdef4dd1c534490e9dc0d95fe48cf34
     - github_key=test
     - github_secret=test
-language: ruby
-rvm:
-  - 2.3.1
+
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
+
 script:
+  - bundle exec db:setup
   - bundle exec rspec
+  - $CC format-coverage --output coverage/codeclimate.$SUITE.json
   - bundle exec cucumber
+  - $CC format-coverage --output coverage/codeclimate.$SUITE.json
+
 after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - $CC sum-coverage coverage/codeclimate.*.json | $CC upload-coverage
+  - $CC after-build --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - ./cc-test-reporter before-build
 
 script:
-  - bundle exec db:setup
+  - bundle exec rake db:setup
   - bundle exec rspec
   - $CC format-coverage --output coverage/codeclimate.$SUITE.json
   - bundle exec cucumber

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_script:
   - ./cc-test-reporter before-build
 
 script:
-  - bundle exec rake db:setup
   - bundle exec rspec
   - $CC format-coverage --output coverage/codeclimate.$SUITE.json
   - bundle exec cucumber

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ before_script:
 
 script:
   - bundle exec rspec
-  - $CC format-coverage --output coverage/codeclimate.$SUITE.json
+  - ./cc-test-reporter format-coverage --output coverage/codeclimate.$SUITE.json
   - bundle exec cucumber
-  - $CC format-coverage --output coverage/codeclimate.$SUITE.json
+  - ./cc-test-reporter format-coverage --output coverage/codeclimate.$SUITE.json
 
 after_script:
-  - $CC sum-coverage coverage/codeclimate.*.json | $CC upload-coverage
-  - $CC after-build --exit-code $TRAVIS_TEST_RESULT
+  - ./cc-test-reporter sum-coverage coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -40,5 +40,5 @@ class CommentsController < ApplicationController
 
 	def comment_params
 		params.require(:comment).permit(:username, :user_id, :content, :app_id)
-    end
+	end
 end

--- a/app/controllers/creation_controller.rb
+++ b/app/controllers/creation_controller.rb
@@ -2,16 +2,16 @@ class CreationController < ApplicationController
 
     def app_params
         params.require(:app).permit(:name, :description, :deployment_url, :repository_url, :code_climate_url, :org_id, :status, :comments)
-    end 
-    
+    end
+
     def user_params
         params.require(:user).permit(:name,:email,:preferred_contact,:github_uid, :type_user, :sid)
     end
-    
+
     def org_params
         params.require(:org).permit(:name, :description, :url, :contact_id, :comments, :address_line_1, :address_line_2, :city_state_zip, :phone, :defunct)
     end
-    
+
     def new
         @user = User.new
         @org = Org.new
@@ -19,13 +19,6 @@ class CreationController < ApplicationController
     end
 
     def  create
-        # byebug
-        # create user, check error. if error. re-render 
-        # create the org, check error, if error, DELETE USER@@@@
-        # create the app, check error, if error, DELETE THE USER AND ORG@@@@@@
-
-        #why am i getting rid of @model specific models again? llolol
-
         @user = User.new(user_params)
         no_user_err = @user.save
         if !no_user_err
@@ -49,9 +42,9 @@ class CreationController < ApplicationController
             @org.destroy
             render :new and return
         end
-        
+
         redirect_to app_path(@app), notice: 'User, Org, and App were successfully created.'
     end
-                
+
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,24 +3,24 @@ module ApplicationHelper
   def field(model, field_name, type = :text_field, options = {})
     "\n".html_safe <<
       content_tag('div', :class => 'field') do
-      [model.label(field_name), '<br/>', model.send(type, field_name, options)].
-        map(&:html_safe).
-        join("\n").
-        html_safe
-    end.html_safe <<
-      "\n"
+        [model.label(field_name), '<br/>', model.send(type, field_name, options)].
+          map(&:html_safe).
+          join("\n").
+          html_safe
+      end.html_safe <<
+        "\n"
   end
 
   def menu_field(model, field_name, printable_name: 'name', model_class: nil)
     model_class ||= field_name.to_s.capitalize.constantize
     foreign_key = "#{field_name}_id"
     content_tag('div', :class => 'field') do
-    [model.label(field_name), '<br/>', 
-      select(model.object_name, foreign_key,
-        options_from_collection_for_select(model_class.send(:all),
-            'id', printable_name, model.object.send(foreign_key)))].
-        map(&:html_safe).
-        join("\n").html_safe
+      [model.label(field_name), '<br/>',
+        select(model.object_name, foreign_key,
+          options_from_collection_for_select(model_class.send(:all),
+              'id', printable_name, model.object.send(foreign_key)))].
+          map(&:html_safe).
+          join("\n").html_safe
     end
   end
 

--- a/app/models/engagement.rb
+++ b/app/models/engagement.rb
@@ -17,7 +17,7 @@ class Engagement < ActiveRecord::Base
   validates_presence_of :student_names
 
   has_many :iterations
-  
+
   has_many :users
 
   default_scope { order('start_date DESC') }
@@ -25,8 +25,8 @@ class Engagement < ActiveRecord::Base
   def summarize_customer_rating
     customer_ratings = iterations.each.map{|iter| iter.customer_rating}
     valid_count = customer_ratings.count {|rating| !rating.empty?}
-    stat_avg = customer_ratings.inject(iterations.create_base_rating_hash) do |cum, cur|
-      cum.merge(cur) {|key, oldValue, newValue| oldValue + newValue / valid_count.to_f}
+    customer_ratings.inject(iterations.create_base_rating_hash) do |cum, cur|
+      cum.merge(cur) {|_key, oldValue, newValue| oldValue + newValue / valid_count.to_f}
     end
   end
 end

--- a/app/models/iteration.rb
+++ b/app/models/iteration.rb
@@ -21,7 +21,7 @@ class Iteration < ActiveRecord::Base
   end
 
   def customer_feedback_with_rating
-    customer_feedback_to_hash.select do |key, value|
+    customer_feedback_to_hash.select do |key, _value|
       Iteration.customer_rating_keys.include? key
     end
   end

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -1,10 +1,8 @@
 class Org < ActiveRecord::Base
-  has_many :apps
+  has_many :apps, :foreign_key => 'org_id'
   belongs_to :contact, :class_name => 'User'
 
   validates :name, :presence => true
-  #validates :url, :contact_name, :contact_email, :presence => true
-
   validates :name, uniqueness: true
 
   default_scope { order :name => :asc }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,8 @@ class User < ActiveRecord::Base
 
   validates_presence_of :name
   validates_presence_of :email
-  
+
   validates :email, uniqueness: true
 
+  has_many :orgs, :foreign_key => 'contact_id'
 end


### PR DESCRIPTION
## [refactor] clean code smells

* turned off code climate engines that we probably don't need (css). If we need any, we can turn them on later
* fix some indentation issues and unnecessary comments
* cyclomatic complexity with creation_controller#create
    - the original implementation was that if any of `@user`, `@org`, `@app` fails, delete all object if saved, and print according error messages at the `:new` action view. Instead of conditional branches, I used ActionRecord::Base.transaction to do the same thing, but with only a few lines.
* .travis.yml was bugging again, so I had to try things.