### PR TITLE
Style/error messages

### DIFF
--- a/app/controllers/creation_controller.rb
+++ b/app/controllers/creation_controller.rb
@@ -26,7 +26,7 @@ class CreationController < ApplicationController
                 @app = @org.apps.create!(app_params)
             end
         rescue ActiveRecord::RecordInvalid => e
-            @errors = [e.message]
+            @error_record = e.record
             render :new and return
         end
         redirect_to app_path(@app), notice: 'User, Org, and App were successfully created.'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,4 +24,8 @@ module ApplicationHelper
     end
   end
 
+  def form_errors_for(object=nil)
+    render 'shared/form_errors', object: object unless object.blank?
+  end
+
 end

--- a/app/views/apps/_form.html.haml
+++ b/app/views/apps/_form.html.haml
@@ -1,12 +1,5 @@
 = form_for(@app) do |f|
-  - if @app.errors.any?
-    #error_explanation.alert.alert-danger
-      %h2
-        = pluralize(@app.errors.count, "error")
-        prohibited this app from being saved:
-      %ul
-        - @app.errors.full_messages.each do |message|
-          %li= message
+  = form_errors_for @app
   = field f, :name
   = field f, :description, :text_area
   = field f, :deployment_url

--- a/app/views/apps/edit.html.haml
+++ b/app/views/apps/edit.html.haml
@@ -1,2 +1,3 @@
-%h1 Editing App "#{@app.name}"
+%h1 Editing App "#{App.find(@app.id).name}"
+
 = render 'form'

--- a/app/views/apps/index.html.haml
+++ b/app/views/apps/index.html.haml
@@ -1,4 +1,3 @@
-%p#notice= notice
 .page-header
   %h1 Listing Apps
   #filters
@@ -8,8 +7,8 @@
       %span{:class => status}= status.humanize
     :javascript
       $('.filter').change(function() { var klass = $("#apps_table ."+$(this).attr('name')).toggle(); });
-      
-    
+
+
 %table.table.table-condensed#apps_table
   %thead
     %tr

--- a/app/views/apps/new.html.haml
+++ b/app/views/apps/new.html.haml
@@ -1,6 +1,3 @@
 %h1 New App
 
 = render 'form'
-
-= link_to 'Back', apps_path, :class => 'btn btn-primary'
-

--- a/app/views/apps/show.html.haml
+++ b/app/views/apps/show.html.haml
@@ -1,6 +1,3 @@
-
-%p#notice= notice
-
 .page-header
   %h1
     = link_to_unless @app.deployment_url.blank?, @app.name, @app.deployment_url, :target => '_blank'

--- a/app/views/comments/edit.html.haml
+++ b/app/views/comments/edit.html.haml
@@ -1,6 +1,7 @@
 %h1 Edit Comment
 
 = form_tag app_comment_path(@comment.app_id, @comment.id), :method => :put do
+  = form_errors_for @comment
   = label :comment, :content, "Edit Comments"
   = text_field :comment, 'content'
 

--- a/app/views/creation/new.html.haml
+++ b/app/views/creation/new.html.haml
@@ -1,12 +1,5 @@
 %h1 Create New User, Org, and App
-- if @errors
-  #error_explanation
-    %h2 #{pluralize(@errors.count, "error")} prohibited this app from being saved:
-
-    %ul
-      - @errors.each do |message|
-        %li= message
-
+= form_errors_for @error_record
 = form_tag creation_path do
   %br
   <div class="row" style="display: table; clear: both;">

--- a/app/views/engagements/_form.html.haml
+++ b/app/views/engagements/_form.html.haml
@@ -1,10 +1,5 @@
-= form_for([@app,@engagement]) do |f| 
-  - if @engagement.errors.any?
-    #error_explanation
-      %h2 #{pluralize(@engagement.errors.count, "error")}  prohibited this engagement from being saved:
-      %ul
-        - @engagement.errors.full_messages.each do |message|
-          %li= message
+= form_for([@app,@engagement]) do |f|
+  = form_errors_for @engagement
 
   %fieldset
     %legend Coaching Info

--- a/app/views/engagements/index.html.haml
+++ b/app/views/engagements/index.html.haml
@@ -1,5 +1,3 @@
-%p#notice= notice
-
 %h1 Engagements
 
 %p.explanation Click on engagement start date or iteration count to view/edit iterations.
@@ -11,17 +9,17 @@
       %th Coach
       %th App
       %th Start date
-      %th Screencast 
-      %th Poster 
-      %th Presentation 
-      %th Prototype deployment 
+      %th Screencast
+      %th Poster
+      %th Presentation
+      %th Prototype deployment
       %th Student names
       %th Iterations
       %th{:colspan => 2}
 
-  %tbody 
+  %tbody
     - @engagements.each do |en|
-      %tr 
+      %tr
         %td= en.coaching_org.try(:name)
         %td= link_to(en.coach.name, user_path(en.coach)) if en.coach
         %td= link_to en.app.name, app_path(en.app)
@@ -30,12 +28,12 @@
         %td= link_to('Poster', en.poster_url) if en.poster_url
         %td= link_to('Presentation', en.presentation_url) if en.presentation_url
         %td= link_to('Deployment', en.prototype_deployment_url) if en.prototype_deployment_url
-        %td= en.student_names 
+        %td= en.student_names
         %td= link_to en.iterations.count, engagement_iterations_path(en)
         %td= link_to 'Show', en, :class => 'btn btn-primary'
-        %td= link_to 'Edit', edit_engagement_path(en), :class => 'btn btn-primary' 
-      
+        %td= link_to 'Edit', edit_engagement_path(en), :class => 'btn btn-primary'
 
-%br 
+
+%br
 
 = link_to 'New Engagement', new_engagement_path , :class => 'btn btn-primary'

--- a/app/views/iterations/_iteration.html.haml
+++ b/app/views/iterations/_iteration.html.haml
@@ -1,10 +1,5 @@
 = form_for([@engagement, @iteration]) do |f|
-  - if @iteration.errors.any?
-    #error_explanation
-      %h2 #{pluralize(@engagement.errors.count, "error")}  prohibited this iteration from being saved:
-      %ul
-        - @iteration.errors.full_messages.each do |message|
-          %li= message
+  = form_errors_for @iteration
 
   %fieldset
     = field f, :end_date, :date_select

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,4 +9,5 @@
     #main.container
       = render 'layouts/nav_header'
       = render 'shared/flash_messages'
+      = yield :form_errors
       = yield

--- a/app/views/orgs/_form.html.haml
+++ b/app/views/orgs/_form.html.haml
@@ -1,12 +1,5 @@
 = form_for(@org) do |f|
-  - if @org.errors.any?
-    #error_explanation
-      %h2 #{pluralize(@org.errors.count, "error")} prohibited this organization from being saved:
-
-      %ul
-        - @org.errors.full_messages.each do |message|
-          %li= message
-
+  = form_errors_for @org
   = field f, :name
   = field f, :address_line_1
   = field f, :address_line_2

--- a/app/views/orgs/edit.html.haml
+++ b/app/views/orgs/edit.html.haml
@@ -1,3 +1,3 @@
-%h1 Editing "#{@org.name}"
+%h1 Editing "#{Org.find(@org.id).name}"
 
 = render 'form'

--- a/app/views/orgs/index.html.haml
+++ b/app/views/orgs/index.html.haml
@@ -1,5 +1,3 @@
-%p#notice= notice
-
 %h1 Organizations
 
 %table.table.table-condensed
@@ -14,10 +12,10 @@
       - @orgs.each do |org|
         %tr{:class => ("defunct" if org.defunct)}
           %td= link_to_unless org.url.blank?, org.name, org.url, :target => '_blank'
-          %td= mail_to org.contact.email, org.contact.name 
-          %td= org.description 
+          %td= mail_to org.contact.email, org.contact.name
+          %td= org.description
           %td= org.apps.map { |a| link_to a.name, app_path(a) }.join(', ').html_safe
-          %td= link_to 'Edit', edit_org_path(org), :title => "Last update: #{org.updated_at.strftime('%c')}", :class => 'btn btn-primary' 
+          %td= link_to 'Edit', edit_org_path(org), :title => "Last update: #{org.updated_at.strftime('%c')}", :class => 'btn btn-primary'
           %td= link_to 'Destroy', org, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-danger'
 
 %br

--- a/app/views/orgs/new.html.erb
+++ b/app/views/orgs/new.html.erb
@@ -1,5 +1,3 @@
 <h1>New Organization</h1>
 
 <%= render 'form' %>
-
-<%= link_to 'Back', orgs_path %>

--- a/app/views/shared/_form_errors.html.haml
+++ b/app/views/shared/_form_errors.html.haml
@@ -1,0 +1,7 @@
+- content_for :form_errors do
+	- if object.errors.any?
+		#error_explanation.alert.alert-danger
+			%h2{style: "margin-top: 0px"}= "#{pluralize(object.errors.count, "error")} prohibited #{object.model_name.human} from being saved:"
+			%ul
+				- object.errors.full_messages.each do |message|
+					%li= message

--- a/app/views/users/user.html.haml
+++ b/app/views/users/user.html.haml
@@ -1,15 +1,7 @@
 %h1 #{action_name.capitalize} User
 
 = form_for(@user) do |f|
-  - if @user.errors.any?
-    #error_explanation.alert.alert-danger
-      %h2
-        = pluralize(@user.errors.count, "error")
-        prevented this user from being saved:
-      %ul
-        - @user.errors.full_messages.each do |message|
-          %li= message
-
+  = form_errors_for @user
   = field f, :name
   = field f, :email
   = field f, :preferred_contact

--- a/features/apps_controller.feature
+++ b/features/apps_controller.feature
@@ -34,7 +34,7 @@ Scenario: Login to github to create a new app
   And I follow "Log in with GitHub"
   And I am on the new_app page
   And I press "Save"
-  And I should see "2 errors prohibited this app from being saved:"
+  And I should see "2 errors prohibited App from being saved:"
   And I should see "App Name can't be blank"
   And I should see "App Description can't be blank"
   When I fill in "App Name" with "Fake app"
@@ -58,7 +58,7 @@ Scenario: Login to github to edit an existing app successfully
   When I fill in "Deployment url" with "Fake app deployment url"
   When I fill in "Repository url" with "Fake app repository "
   And I press "Save"
-  Then I should be on the apps page 
+  Then I should be on the apps page
   And I should see "App was successfully updated."
 
 Scenario: Login to github to edit an existing app successfully

--- a/features/engagement_users.feature
+++ b/features/engagement_users.feature
@@ -2,7 +2,7 @@ Feature: engagement owns users working on that project / app
    As a staff who uses the app
    I want each engagement links to User objects
    So that I can easily assign students to an app
- 
+
 Background: Logged in
    Given the following apps exist:
        | name  | description | org_id | status  |
@@ -26,7 +26,7 @@ Background: Logged in
 
    And I'm logged in on the orgs page
    And I follow "Apps"
-   
+
 Scenario: Can create an engagement with Team members
    #Story ID: #152298585
    Given I follow "app1"
@@ -34,7 +34,7 @@ Scenario: Can create an engagement with Team members
    Then I should see "Team members"
    And I select "user1 user2 user3" as Team members
    And I press "Save"
-   Then I should see "2 errors prohibited this engagement from being saved:"
+   Then I should see "2 errors prohibited Engagement from being saved:"
 
 Scenario: Can create an engagement with Team members
    #Story ID: #152298585
@@ -48,7 +48,7 @@ Scenario: Can create an engagement with Team members
    And I press "Save"
    Then I should see "Engagement was successfully created."
    And I should see "user1"
-   
+
 Scenario: Can update an engagement's team mumbers
    #Story ID: #152298585
    Given I follow "app1"


### PR DESCRIPTION
### REUSE Error Messages Template ###

Almost all models had a view that prints out error messages of an object that either failed to be created or updated due to validation by the model. Since the code for error messages was generated by the rails, it was not very DRY, so I created a shared form that every model can use to display error messages. We still have the flash messages displayed if any `:alert` or `:notice` attribute is set.