### PR TITLE
Feature/search dropdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :production do
   gem 'rails_12factor'
 end
 
+gem 'jquery-ui-rails'
 gem 'json'
 gem 'figaro'
 gem 'haml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (6.0.1)
+      railties (>= 3.2.16)
     json (1.8.6)
     jwt (1.5.6)
     listen (3.1.5)
@@ -310,6 +312,7 @@ DEPENDENCIES
   jasmine-rails
   jbuilder (~> 2.0)
   jquery-rails
+  jquery-ui-rails
   json
   omniauth-github
   pg

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,7 @@
 // about supported directives.
 //
 //= require jquery
-//= require bootstrap-sprockets
+//= require jquery-ui
 //= require jquery_ujs
+//= require bootstrap-sprockets
 //= require_tree .

--- a/app/assets/javascripts/apps.js
+++ b/app/assets/javascripts/apps.js
@@ -1,0 +1,5 @@
+jQuery(function() {
+  return $('#app_org_name').autocomplete({
+    source: $('#app_org_name').data('autocomplete-source')
+  });
+});

--- a/app/assets/javascripts/engagements.coffee
+++ b/app/assets/javascripts/engagements.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/engagements.js
+++ b/app/assets/javascripts/engagements.js
@@ -1,0 +1,17 @@
+jQuery(function() {
+  return $('#engagement_org_name').autocomplete({
+    source: $('#engagement_org_name').data('autocomplete-source')
+  });
+});
+
+jQuery(function() {
+  return $('#engagement_coach_name').autocomplete({
+    source: $('#engagement_coach_name').data('autocomplete-source')
+  });
+});
+
+jQuery(function() {
+  return $('#engagement_contact_name').autocomplete({
+    source: $('#engagement_contact_name').data('autocomplete-source')
+  });
+});

--- a/app/assets/javascripts/orgs.coffee
+++ b/app/assets/javascripts/orgs.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/orgs.js
+++ b/app/assets/javascripts/orgs.js
@@ -1,0 +1,5 @@
+jQuery(function() {
+  return $('#org_contact_name').autocomplete({
+    source: $('#org_contact_name').data('autocomplete-source')
+  });
+});

--- a/app/assets/javascripts/orgs.js
+++ b/app/assets/javascripts/orgs.js
@@ -3,3 +3,11 @@ jQuery(function() {
     source: $('#org_contact_name').data('autocomplete-source')
   });
 });
+
+
+// problem: only get list of items when you type SOMETHING.. lol
+//  should just make org contact REQUIRED... bc on orgs page it lists the contacts email.
+//  org: contact can't be blank
+// engagement: Coaching org and coach required (also add contact required?)
+//  do i just need validates :contact? what are the differences between all validates stuff
+// sean says validates presence

--- a/app/assets/javascripts/orgs.js
+++ b/app/assets/javascripts/orgs.js
@@ -3,11 +3,3 @@ jQuery(function() {
     source: $('#org_contact_name').data('autocomplete-source')
   });
 });
-
-
-// problem: only get list of items when you type SOMETHING.. lol
-//  should just make org contact REQUIRED... bc on orgs page it lists the contacts email.
-//  org: contact can't be blank
-// engagement: Coaching org and coach required (also add contact required?)
-//  do i just need validates :contact? what are the differences between all validates stuff
-// sean says validates presence

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,3 +2,54 @@
 @import "site";
 @import "comments";
 @import "iterations";
+@import "jquery-ui/autocomplete";
+/*https://stackoverflow.com/questions/17838380/styling-jquery-ui-autocomplete*/
+  .ui-autocomplete {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 1000;
+    float: left;
+    display: none;
+    min-width: 160px;   
+    padding: 4px 4px;
+    margin: 0 0 10px 25px;
+    list-style: none;
+    background-color: #ffffff;
+    border-color: #ccc;
+    border-color: rgba(0, 0, 0, 0.2);
+    border-style: solid;
+    border-width: 1px;
+    -webkit-border-radius: 5px;
+    -moz-border-radius: 5px;
+    border-radius: 5px;
+    -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+    -moz-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+    -webkit-background-clip: padding-box;
+    -moz-background-clip: padding;
+    background-clip: padding-box;
+    *border-right-width: 2px;
+    *border-bottom-width: 2px;
+}
+
+.ui-menu-item > a.ui-corner-all {
+    display: block;
+    padding: 3px 15px;
+    clear: both;
+    font-weight: normal;
+    line-height: 18px;
+    color: #555555;
+    white-space: nowrap;
+    text-decoration: none;
+}
+
+.ui-state-hover, .ui-state-active {
+    color: #ffffff;
+    text-decoration: none;
+    background-color: #0088cc;
+    border-radius: 0px;
+    -webkit-border-radius: 0px;
+    -moz-border-radius: 0px;
+    background-image: none;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@
 @import "comments";
 @import "iterations";
 @import "jquery-ui/autocomplete";
+/*This the styling for the auto complete */
 /*https://stackoverflow.com/questions/17838380/styling-jquery-ui-autocomplete*/
   .ui-autocomplete {
     position: absolute;
@@ -53,3 +54,5 @@
     -moz-border-radius: 0px;
     background-image: none;
 }
+/*This hides the auto complete related helper text*/
+.ui-helper-hidden-accessible { display:none; }

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -7,6 +7,7 @@ class AppsController < ApplicationController
   def index
     @current_user = User.find_by_id(session[:user_id])
     @apps = App.all
+    byebug
     respond_to do |format|
       format.json { render :json => @apps.featured }
       format.html

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -77,6 +77,6 @@ class AppsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def app_params
-      params.require(:app).permit(:name, :description, :deployment_url, :repository_url, :code_climate_url, :org_id, :status, :comments)
+      params.require(:app).permit(:name, :description, :deployment_url, :repository_url, :code_climate_url, :org_name, :status, :comments)
     end
 end

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -7,7 +7,6 @@ class AppsController < ApplicationController
   def index
     @current_user = User.find_by_id(session[:user_id])
     @apps = App.all
-    byebug
     respond_to do |format|
       format.json { render :json => @apps.featured }
       format.html

--- a/app/controllers/engagements_controller.rb
+++ b/app/controllers/engagements_controller.rb
@@ -18,6 +18,7 @@ class EngagementsController < ApplicationController
   # POST /engagements.json
   def create
     @engagement = @app.engagements.build(engagement_params)
+
     if @engagement.save
       redirect_to @app, notice: 'Engagement was successfully created.'
     else
@@ -76,7 +77,7 @@ class EngagementsController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def engagement_params
     params.require(:engagement).
-      permit(:coach_id, :coaching_org_id, :contact_id, :app_id, :team_number,
+      permit(:coach_name, :org_name, :contact_name, :app_id, :team_number,
       :start_date, :screencast_url, :poster_preview_url, :poster_url,
       :presentation_url, :prototype_deployment_url, :student_names,
       :repository_url, :user_ids => [])

--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -20,7 +20,6 @@ class OrgsController < ApplicationController
   # POST /orgs.json
   def create
     @org = Org.new(org_params)
-
     respond_to do |format|
       if @org.save
         format.html { redirect_to orgs_path, notice: 'Org was successfully created.' }
@@ -76,7 +75,7 @@ class OrgsController < ApplicationController
     def org_params
       params.
         require(:org).
-        permit(:name, :description, :url, :contact_id,
+        permit(:name, :description, :url, :contact_name,
       :address_line_1, :address_line_2, :city_state_zip, :phone, :defunct)
     end
 end

--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -20,7 +20,6 @@ class OrgsController < ApplicationController
   # POST /orgs.json
   def create
     @org = Org.new(org_params)
-    byebug
     respond_to do |format|
       if @org.save
         format.html { redirect_to orgs_path, notice: 'Org was successfully created.' }

--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -20,6 +20,7 @@ class OrgsController < ApplicationController
   # POST /orgs.json
   def create
     @org = Org.new(org_params)
+    byebug
     respond_to do |format|
       if @org.save
         format.html { redirect_to orgs_path, notice: 'Org was successfully created.' }

--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -56,6 +56,16 @@ class OrgsController < ApplicationController
     end
   end
 
+  def autocomplete
+    @orgs = Org.order(:name).where("name LIKE ?", "%#{params[:term]}%")
+    respond_to do |format|
+      format.html
+      format.json {
+        render json: @orgs.map(&:name).to_json
+      }
+    end
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_org

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,6 +32,16 @@ class UsersController < ApplicationController
     end
   end
 
+  def autocomplete
+    @users = User.order(:name).where("name LIKE ?", "%#{params[:term]}%")
+    respond_to do |format|
+      format.html
+      format.json {
+        render json: @users.map(&:name).to_json
+      }
+    end
+  end
+
   private
   # Never trust parameters from the scary internet, only allow the white list through.
   def user_params

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -23,4 +23,11 @@ class App < ActiveRecord::Base
     status == "pending"
   end
 
+  def org_name
+    org.try(:name)
+  end
+
+  def org_name=(name)
+    self.org = Org.find_by(name: name) if name.present?
+  end
 end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -24,7 +24,7 @@ class App < ActiveRecord::Base
   end
 
   def org_name
-    org.try(:name)
+    self.org.try(:name)
   end
 
   def org_name=(name)

--- a/app/models/engagement.rb
+++ b/app/models/engagement.rb
@@ -29,4 +29,29 @@ class Engagement < ActiveRecord::Base
       cum.merge(cur) {|_key, oldValue, newValue| oldValue + newValue / valid_count.to_f}
     end
   end
+
+  def org_name
+    self.coaching_org.try(:name)
+  end
+
+  def org_name=(name)
+    self.coaching_org = Org.find_by(name: name) if name.present?
+  end
+
+  def contact_name
+    self.contact.try(:name)
+  end
+
+  def contact_name=(name)
+    self.contact = User.find_by(name: name) if name.present?
+  end
+
+  def coach_name
+    self.coach.try(:name)
+  end
+
+  def coach_name=(name)
+    self.coach = User.find_by(name: name) if name.present?
+  end
+
 end

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -5,6 +5,7 @@ class Org < ActiveRecord::Base
 
   validates :name, :presence => true
   validates :name, uniqueness: true
+  # validates :contact_name, :presence => true
 
   default_scope { order :name => :asc }
 

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -5,7 +5,7 @@ class Org < ActiveRecord::Base
 
   validates :name, :presence => true
   validates :name, uniqueness: true
-  # validates :contact_name, :presence => true
+  validates :contact_name, :presence => true
 
   default_scope { order :name => :asc }
 

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -13,4 +13,12 @@ class Org < ActiveRecord::Base
   def address
   	[address_line_1, address_line_2, city_state_zip].join("\n").squish
   end
+
+  def contact_name
+    self.contact.try(:name)
+  end
+
+  def contact_name=(name)
+    self.contact = User.find_by(name: name) if name.present?
+  end
 end

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -5,7 +5,7 @@ class Org < ActiveRecord::Base
 
   validates :name, :presence => true
   validates :name, uniqueness: true
-  validates :contact_name, :presence => true
+  validates :contact_id, :presence => true
 
   default_scope { order :name => :asc }
 

--- a/app/views/apps/_form.html.haml
+++ b/app/views/apps/_form.html.haml
@@ -7,7 +7,7 @@
   = field f, :code_climate_url
   %br
   = label :org, :org_name, 'Organization'
-  = f.text_field :org_name, data: { autocomplete_source: autocomplete_path}
+  = f.text_field :org_name, data: { autocomplete_source: orgs_autocomplete_path}
   %br
   = f.label 'Status'
   = f.collection_select :status, App.statuses, :first, ->(x) { x.first.humanize }

--- a/app/views/apps/_form.html.haml
+++ b/app/views/apps/_form.html.haml
@@ -5,7 +5,10 @@
   = field f, :deployment_url
   = field f, :repository_url
   = field f, :code_climate_url
-  = menu_field f, :org
+  %br
+  = label :org, :org_name, 'Organization'
+  = f.text_field :org_name, data: { autocomplete_source: autocomplete_path}
+  %br
   = f.label 'Status'
   = f.collection_select :status, App.statuses, :first, ->(x) { x.first.humanize }
   .actions

--- a/app/views/engagements/_form.html.haml
+++ b/app/views/engagements/_form.html.haml
@@ -4,9 +4,17 @@
   %fieldset
     %legend Coaching Info
     = field f, :start_date, :date_select
-    = menu_field f, :coaching_org, :model_class => Org
-    = menu_field f, :coach, :model_class => User
-    = menu_field f, :contact, :model_class => User
+
+    %br
+    = label :engagement, :org_name, 'Coaching Org'
+    = f.text_field :org_name, data: { autocomplete_source: orgs_autocomplete_path}
+    %br
+    = label :engagement, :coach_name, 'Coach'
+    = f.text_field :coach_name, data: { autocomplete_source: users_autocomplete_path}
+    %br
+    = label :engagement, :contact_name, 'Contact'
+    = f.text_field :contact_name, data: { autocomplete_source: users_autocomplete_path}
+    %br
 
   %fieldset
     %legend Team Info and Work Products

--- a/app/views/orgs/_form.html.haml
+++ b/app/views/orgs/_form.html.haml
@@ -8,7 +8,12 @@
   = field f, :description, :text_area
   = field f, :url
   = field f, :defunct, :check_box
-  = menu_field f, :contact, :model_class => User
+  / = menu_field f, :contact, :model_class => User
+  %br
+  = label :org, :contact_name, 'Contact'
+  = f.text_field :contact_name, data: { autocomplete_source: users_autocomplete_path} # :contact_id should be defined in org model undefined method `org_name' for #<App:0x007fbf22f3b748>
+  %br
+
   .actions
     = f.submit 'Save', :class => 'btn btn-success'
     = link_to 'Back', orgs_path, :class => 'btn btn-primary'

--- a/app/views/orgs/_form.html.haml
+++ b/app/views/orgs/_form.html.haml
@@ -8,7 +8,6 @@
   = field f, :description, :text_area
   = field f, :url
   = field f, :defunct, :check_box
-  / = menu_field f, :contact, :model_class => User
   %br
   = label :org, :contact_name, 'Contact'
   = f.text_field :contact_name, data: { autocomplete_source: users_autocomplete_path} 

--- a/app/views/orgs/_form.html.haml
+++ b/app/views/orgs/_form.html.haml
@@ -11,7 +11,7 @@
   / = menu_field f, :contact, :model_class => User
   %br
   = label :org, :contact_name, 'Contact'
-  = f.text_field :contact_name, data: { autocomplete_source: users_autocomplete_path} # :contact_id should be defined in org model undefined method `org_name' for #<App:0x007fbf22f3b748>
+  = f.text_field :contact_name, data: { autocomplete_source: users_autocomplete_path} 
   %br
 
   .actions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,5 +32,7 @@ Rails.application.routes.draw do
   post 'creation' => 'creation#create', :as => 'create_all'
   
   get '/apps/:app_id/engagements/:id/export' => 'engagements#export', :as => 'export'
-  get 'autocomplete' => 'orgs#autocomplete', :as => 'autocomplete'
+  get 'orgs_autocomplete' => 'orgs#autocomplete', :as => 'orgs_autocomplete'
+  get 'users_autocomplete' => 'users#autocomplete', :as => 'users_autocomplete'
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,4 +32,5 @@ Rails.application.routes.draw do
   post 'creation' => 'creation#create', :as => 'create_all'
   
   get '/apps/:app_id/engagements/:id/export' => 'engagements#export', :as => 'export'
+  get 'autocomplete' => 'orgs#autocomplete', :as => 'autocomplete'
 end

--- a/features/apps_controller.feature
+++ b/features/apps_controller.feature
@@ -8,14 +8,14 @@ Background: users, orgs and apps have been added to database
   Given the following apps exist:
         | name  | description | org_id | status  |
         | app1  | test        | 1      | pending |
-        | app2  | test        | 1      | pending |
-        | app3  | test        | 1      | pending |
+        | app2  | test        | 2      | pending |
+        | app3  | test        | 3      | pending |
 
     And the following orgs exist:
-        | name | contact_id | contact_name|
-        | org1 | 1          | user1|
-        | org2 | 1          | user2|
-        | org3 | 1          | user3|
+        | name | id | contact_id |
+        | org1 | 1  | 1          |
+        | org2 | 2  | 1          |
+        | org3 | 3  | 1          |
 
     And the following users exist:
         | name  | github_uid      | email         |

--- a/features/apps_controller.feature
+++ b/features/apps_controller.feature
@@ -12,10 +12,10 @@ Background: users, orgs and apps have been added to database
         | app3  | test        | 1      | pending |
 
     And the following orgs exist:
-        | name | contact_id |
-        | org1 | 1          |
-        | org2 | 1          |
-        | org3 | 1          |
+        | name | contact_id | contact_name|
+        | org1 | 1          | user1|
+        | org2 | 1          | user2|
+        | org3 | 1          | user3|
 
     And the following users exist:
         | name  | github_uid      | email         |

--- a/features/apps_controller.feature
+++ b/features/apps_controller.feature
@@ -34,13 +34,15 @@ Scenario: Login to github to create a new app
   And I follow "Log in with GitHub"
   And I am on the new_app page
   And I press "Save"
-  And I should see "2 errors prohibited App from being saved:"
+  And I should see "3 errors prohibited App from being saved:"
   And I should see "App Name can't be blank"
   And I should see "App Description can't be blank"
+  And I should see "Org can't be blank"
   When I fill in "App Name" with "Fake app"
   When I fill in "App Description" with "Fake app description "
   When I fill in "Deployment url" with "Fake app deployment url"
   When I fill in "Repository url" with "Fake app repository "
+  When I fill in "app[org_name]" with "org1"
   And I press "Save"
   Then I should be on the apps page
   And I should see "App was successfully created."
@@ -54,9 +56,9 @@ Scenario: Login to github to edit an existing app successfully
   And I follow "Log in with GitHub"
   And I should see "Editing App"
   When I fill in "App Name" with "Fake app"
-  When I fill in "App Description" with "Fake app description "
+  When I fill in "App Description" with "Fake app description"
   When I fill in "Deployment url" with "Fake app deployment url"
-  When I fill in "Repository url" with "Fake app repository "
+  When I fill in "Repository url" with "Fake app repository"
   And I press "Save"
   Then I should be on the apps page
   And I should see "App was successfully updated."

--- a/features/create_org.feature
+++ b/features/create_org.feature
@@ -28,6 +28,8 @@ Scenario: I can create an org
     And I fill in the "New Organization" fields as follows:
         | field                     | value             |
         | org[name]                 | org1              |
+        | org[contact_name]         | user1              |
+
     And I press "Save"
     Then I should see "Org was successfully created."
 
@@ -37,4 +39,6 @@ Scenario: I cannot submit with org name field blank
         | org[name]                 |                   |
     And I press "Save"
     Then I should see "Org Name can't be blank"
+    Then I should see "Contact name can't be blank"
+
 

--- a/features/create_org.feature
+++ b/features/create_org.feature
@@ -39,6 +39,6 @@ Scenario: I cannot submit with org name field blank
         | org[name]                 |                   |
     And I press "Save"
     Then I should see "Org Name can't be blank"
-    Then I should see "Contact name can't be blank"
+    Then I should see "Contact can't be blank"
 
 

--- a/features/duplicatecheck.feature
+++ b/features/duplicatecheck.feature
@@ -11,10 +11,10 @@ Background: User is trying to sign up
         | org3 | 3          |
 
     And the following users exist:
-        | name  | github_uid      | email          |
-        | user1 | esaas_developer | user1@user.com |
-        | user2 |                 | user2@user.com |
-        | user3 |                 | user3@user.com |
+        | name  | id | github_uid      | email          |
+        | user1 | 1 | esaas_developer | user1@user.com |
+        | user2 | 2 |                 | user2@user.com |
+        | user3 | 3 |                 | user3@user.com |
     
     And I'm logged in on the orgs page
 
@@ -39,7 +39,10 @@ Scenario: user fills in information in new user page
 Scenario: user fills in information in new org page
     Given I am on the Orgs page
     When I follow "New Org"
-    And I fill in "Org Name" with "org1"
+    And I fill in the "New Organization" fields as follows:
+        | field                     | value             |
+        | org[name]                 | org1              |
+        | org[contact_name]         | user1              |
     And I press "Save"
     Then I should see "Org Name has already been taken"
     And I should not see "Org was successfully created."

--- a/features/duplicatecheck.feature
+++ b/features/duplicatecheck.feature
@@ -50,7 +50,10 @@ Scenario: user fills in information in new org page
 Scenario: user fills in information in new org page
     Given I am on the Orgs page
     When I follow "New Org"
-    And I fill in "Org Name" with "new_org"
+    And I fill in the "New Organization" fields as follows:
+        | field                     | value             |
+        | org[name]                 | new_org              |
+        | org[contact_name]         | user1              |
     And I press "Save"
     Then I should see "Org was successfully created."
     Then I should not see "Org Name has already been taken"

--- a/features/edit_destroy.feature
+++ b/features/edit_destroy.feature
@@ -58,7 +58,10 @@ Scenario: Newly Added Engagement also has buttons
    Given I create a new engagement for "app1"
    When I fill in the engagement fields as follows:
        | field                  | value      |
-       | Team number            | Team3          |
+       | Coaching Org           | org1       |
+       | Coach                  | user1      |
+       | Contact                | user2      |
+       | Team number            | Team3      |
        | Student names          | Student1   |
   And I press "Save"
   Then I should see "Engagement was successfully created"

--- a/features/engagement_users.feature
+++ b/features/engagement_users.feature
@@ -34,7 +34,7 @@ Scenario: Can create an engagement with Team members
    Then I should see "Team members"
    And I select "user1 user2 user3" as Team members
    And I press "Save"
-   Then I should see "2 errors prohibited Engagement from being saved:"
+   Then I should see "4 errors prohibited Engagement from being saved:"
 
 Scenario: Can create an engagement with Team members
    #Story ID: #152298585
@@ -44,6 +44,9 @@ Scenario: Can create an engagement with Team members
        | field                  | value      |
        | Team number            | Team1      |
        | Student names          | Student1   |
+       | Coaching Org           | org1       |
+       | Coach                  | user1      |
+       | Contact                | user2      |
    And I select "user1 user2 user3" as Team members
    And I press "Save"
    Then I should see "Engagement was successfully created."
@@ -57,6 +60,9 @@ Scenario: Can update an engagement's team mumbers
        | field                  | value      |
        | Team number            | Team1      |
        | Student names          | Student1   |
+       | Coaching Org           | org1       |
+       | Coach                  | user1      |
+       | Contact                | user2      |
    And I select "user1 user2 user3" as Team members
    And I press "Save"
    Then I should see "Engagement was successfully created."

--- a/features/search_dropdown.feature
+++ b/features/search_dropdown.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: when creating an app, the orgs dropdown should be searchable
 As a user of the app
 So that I do not have to look through a long list of dropdown menu
@@ -18,9 +17,12 @@ Background: user and orgs have been added to database
 
   And I'm logged in on the orgs page
   
+@javascript
 Scenario: I can search the dropdown list of orgs
   # Story ID: 153069853
   Given I am on the new app page
-  And I fill in "organization" with "org"
-  Then I should see "org3"
-  And I should see "org4"
+  When I type in "org" into autocomplete list "app[org_name]"
+  Then I should see "org3" in the autocomplete list "app[org_name]"
+  Then I should see "org4" in the autocomplete list "app[org_name]"
+  Then I should not see "Berkeley" in the autocomplete list "app[org_name]"
+  Then I should not see "Stanford" in the autocomplete list "app[org_name]"

--- a/features/search_dropdown.feature
+++ b/features/search_dropdown.feature
@@ -17,6 +17,11 @@ Background: user and orgs have been added to database
         | user2             | 2  |                 | test2@user.com |
         | cal student       | 3  |                 | test3@user.com |
         | stanford student  | 4  |                 | test4@user.com |
+  And the following apps exist:
+        | name  | id | description | org_id | status  |
+        | app1  | 1  | test        | 1      | pending |
+        | app2  | 2  | test        | 1      | pending |
+        | app3  | 3  | test        | 1      | pending |
 
   And I'm logged in on the orgs page
   
@@ -29,39 +34,3 @@ Scenario: I can search the dropdown list of orgs when creating a new app
   Then I should see "org4" in the autocomplete list "app[org_name]"
   Then I should not see "Berkeley" in the autocomplete list "app[org_name]"
   Then I should not see "Stanford" in the autocomplete list "app[org_name]"
-
-@javascript
-Scenario: I can search the dropdown list of users when creating a new org
-  # Story ID: 153069853
-  #Given I am on the new org page
-  #When I type in "stu" into autocomplete list "org[contact_name]"
-  #Then I should see "cal student" in the autocomplete list "org[contact_name]"
-  #Then I should see "stanford student" in the autocomplete list "org[contact_name]"
-  #Then I should not see "user1" in the autocomplete list "org[contact_name]"
-  #Then I should not see "user2" in the autocomplete list "org[contact_name]"
-  Given I am on the new org page
-  When I type in "u" into autocomplete list "org[contact_name]"
-  Then I should see "user2" in the autocomplete list "org[contact_name]"
-  Then I should not see "cal student" in the autocomplete list "org[contact_name]"
-  Then I should not see "stanford student" in the autocomplete list "org[contact_name]"
-
-#Scenario: I can still create a new app as usual with this new feature added
-#  # Story ID: 153069853
-#  Given I am on the new app page
-#  When I fill in "App Name" with "Fake app"
-#  When I fill in "App Description" with "Fake app description"
-#  When I fill in "Deployment url" with "Fake app deployment url"
-#  When I fill in "Repository url" with "Fake app repository"
-#  When I fill in "app[org_name]" with "org1"
-#  And I press "Save"
-#  Then I should be on the apps page
-#  And I should see "App was successfully created."
-#
-#Scenario: I can still create a new org as usual with this new feature added
-#  # Story ID: 153069853
-#  Given I am on the new org page
-#  And I fill in "Org Name" with "fakeorg"
-#  When I fill in "org[contact_name]" with "user1"
-#  Then I press "Save"
-#  Then I should be on the orgs page
-#  Then I should see "Org was successfully created."

--- a/features/search_dropdown.feature
+++ b/features/search_dropdown.feature
@@ -7,18 +7,21 @@ Background: user and orgs have been added to database
   And the following orgs exist:
         | id | name     | contact_id |
         | 1  | Berkeley | 1          |
-        | 2  | Stanford | 1          |
-        | 3  | org3     | 1          |
-        | 4  | org4     | 1          |
+        | 2  | Stanford | 2          |
+        | 3  | org3     | 3          |
+        | 4  | org4     | 4          |
 
   And the following users exist:
-        | name  | github_uid      | email         |
-        | user1 | esaas_developer | test@user.com |
+        | name              | id | github_uid      | email          |
+        | user1             | 1  | esaas_developer | test1@user.com |
+        | user2             | 2  |                 | test2@user.com |
+        | cal student       | 3  |                 | test3@user.com |
+        | stanford student  | 4  |                 | test4@user.com |
 
   And I'm logged in on the orgs page
   
 @javascript
-Scenario: I can search the dropdown list of orgs
+Scenario: I can search the dropdown list of orgs when creating a new app
   # Story ID: 153069853
   Given I am on the new app page
   When I type in "org" into autocomplete list "app[org_name]"
@@ -26,3 +29,39 @@ Scenario: I can search the dropdown list of orgs
   Then I should see "org4" in the autocomplete list "app[org_name]"
   Then I should not see "Berkeley" in the autocomplete list "app[org_name]"
   Then I should not see "Stanford" in the autocomplete list "app[org_name]"
+
+@javascript
+Scenario: I can search the dropdown list of users when creating a new org
+  # Story ID: 153069853
+  #Given I am on the new org page
+  #When I type in "stu" into autocomplete list "org[contact_name]"
+  #Then I should see "cal student" in the autocomplete list "org[contact_name]"
+  #Then I should see "stanford student" in the autocomplete list "org[contact_name]"
+  #Then I should not see "user1" in the autocomplete list "org[contact_name]"
+  #Then I should not see "user2" in the autocomplete list "org[contact_name]"
+  Given I am on the new org page
+  When I type in "u" into autocomplete list "org[contact_name]"
+  Then I should see "user2" in the autocomplete list "org[contact_name]"
+  Then I should not see "cal student" in the autocomplete list "org[contact_name]"
+  Then I should not see "stanford student" in the autocomplete list "org[contact_name]"
+
+#Scenario: I can still create a new app as usual with this new feature added
+#  # Story ID: 153069853
+#  Given I am on the new app page
+#  When I fill in "App Name" with "Fake app"
+#  When I fill in "App Description" with "Fake app description"
+#  When I fill in "Deployment url" with "Fake app deployment url"
+#  When I fill in "Repository url" with "Fake app repository"
+#  When I fill in "app[org_name]" with "org1"
+#  And I press "Save"
+#  Then I should be on the apps page
+#  And I should see "App was successfully created."
+#
+#Scenario: I can still create a new org as usual with this new feature added
+#  # Story ID: 153069853
+#  Given I am on the new org page
+#  And I fill in "Org Name" with "fakeorg"
+#  When I fill in "org[contact_name]" with "user1"
+#  Then I press "Save"
+#  Then I should be on the orgs page
+#  Then I should see "Org was successfully created."

--- a/features/step_definitions/search_dropdown_steps.rb
+++ b/features/step_definitions/search_dropdown_steps.rb
@@ -1,6 +1,10 @@
 When /^I type in "([^\"]*)" into autocomplete list "([^\"]*)"$/ do |typed, input_name|
     page.execute_script %Q{$('#{input_name}').val('#{typed}').keydown()}
+    page.execute_script %Q{$('#{input_name}').trigger("focus") }
+    page.execute_script %Q{$('#{input_name}').trigger("keydown") }
+
     fill_in("#{input_name}",:with => typed)
+    sleep 2
 end
 
 Then /^I should see "([^\"]*)" in the autocomplete list "([^\"]*)"$/ do |option, input_name|

--- a/features/step_definitions/search_dropdown_steps.rb
+++ b/features/step_definitions/search_dropdown_steps.rb
@@ -1,0 +1,12 @@
+When /^I type in "([^\"]*)" into autocomplete list "([^\"]*)"$/ do |typed, input_name|
+    page.execute_script %Q{$('#{input_name}').val('#{typed}').keydown()}
+    fill_in("#{input_name}",:with => typed)
+end
+
+Then /^I should see "([^\"]*)" in the autocomplete list "([^\"]*)"$/ do |option, input_name|
+    find('ul.ui-autocomplete').should have_content(option)
+end
+
+Then /^I should not see "([^\"]*)" in the autocomplete list "([^\"]*)"$/ do |option, input_name|
+    find('ul.ui-autocomplete').should_not have_content(option)
+end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -52,6 +52,9 @@ module NavigationHelpers
 
     when /^the new app page$/ then new_app_path
 
+    when /^the new org page$/ then new_org_path
+
+
     # Add more mappings here.
     # Here is an example that pulls values out of the Regexp:
     #


### PR DESCRIPTION
The autocomplete feature using jquery UI autocomplete is now available for:
new/edit app -> selecting an org
new/edit org -> selecting a contact
new/edit engagement -> selecting coaching org, coach, contact

Since the autocomplete feature makes its input field empty by default, there was a problem with create/edit orgs because if a user forgot to enter in a contact, it wouldn't be caught since org never validated presence of a contact. (So if you tried to see index page of orgs, it would give you an error page saying a certain org has no contact, so org.contact.email would error out)

That was fixed by just adding validates :contact_id, :presence => true to the org model. And also updating the cucumber test files to match this new requirement.

Engagements already validated presence of a coaching org and coach. Apps already validated presence of an org. So there were no problem there.