### PR TITLE
[feature] general feedback

### DIFF
--- a/app/controllers/iterations_controller.rb
+++ b/app/controllers/iterations_controller.rb
@@ -29,8 +29,8 @@ class IterationsController < ApplicationController
   def update
     feedback = feedback_params
     @iteration.customer_feedback = feedback.to_json
-    new_end_date = params.require(:iteration).permit(:end_date)
-    if @iteration.save and @iteration.update(new_end_date)
+    new_params = params.require(:iteration).permit(:end_date, :general_feedback)
+    if @iteration.save and @iteration.update(new_params)
       redirect_to engagement_iterations_path(@engagement), notice: 'Iteration was successfully updated.'
     else
       render :edit
@@ -83,7 +83,7 @@ class IterationsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def iteration_params
-    params.require(:iteration).permit(:customer_feedback, :end_date)
+    params.require(:iteration).permit(:customer_feedback, :end_date, :general_feedback)
   end
 
   def feedback_params

--- a/app/views/iterations/_iteration.html.haml
+++ b/app/views/iterations/_iteration.html.haml
@@ -3,7 +3,8 @@
 
   %fieldset
     = field f, :end_date, :date_select
-    = field f, :customer_feedback, :text_area, :size => '80x6'
+    /= field f, :customer_feedback, :text_area, :size => '80x6'
+    = field f, :general_feedback, :text_area, :size => '80x6'
 
     .actions
       = f.submit 'Save', :class => 'btn btn-success'

--- a/app/views/iterations/edit.html.haml
+++ b/app/views/iterations/edit.html.haml
@@ -53,7 +53,10 @@
     = label :customer_feedback, "Satisfied Comments: "
     = text_field :customer_feedback, :satisfied_text, :value => @feedback["satisfied_text"]
     %br
+    %br
 
+    = label :iteration, "General Feedback: "
+    = text_field :iteration, :general_feedback, :size => '80x6'
     %br
     = submit_tag 'Save Changes', :class => 'btn btn-success'
     = link_to 'Back to App', app_path(@engagement.app), :class => 'btn btn-primary'

--- a/app/views/iterations/index.html.haml
+++ b/app/views/iterations/index.html.haml
@@ -23,6 +23,7 @@
       %th Understanding
       %th Effectiveness
       %th Customer Satisfaction
+      %th General Feedback
   %tbody
     - @engagement.iterations.each do |iter|
       - h = iter.customer_feedback_to_hash
@@ -38,3 +39,4 @@
                 %td{:style => "width:232px"}= "#{text.gsub(/_text/, '')}: #{h[text]}"
         - Iteration.customer_rating_keys.each do |rating|
           %td=Iteration.rating_to_score(h[rating]) || "No Data"
+        %td=iter.general_feedback

--- a/db/migrate/20171204012819_add_general_feedback_to_iterations.rb
+++ b/db/migrate/20171204012819_add_general_feedback_to_iterations.rb
@@ -1,0 +1,5 @@
+class AddGeneralFeedbackToIterations < ActiveRecord::Migration
+  def change
+    add_column :iterations, :general_feedback, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171202224507) do
+ActiveRecord::Schema.define(version: 20171204012819) do
 
   create_table "apps", force: :cascade do |t|
     t.integer  "org_id"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 20171202224507) do
     t.datetime "end_date"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "general_feedback"
   end
 
   create_table "orgs", force: :cascade do |t|

--- a/features/general_feedback.feature
+++ b/features/general_feedback.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: when adding a new iteration, the user can add a general feedback
   As a customer of an engagement/iteration
   So that I can fill out a general comment on each iteration before the full/comprehensive customer feedback
@@ -18,15 +17,33 @@ Background: user, org, app, and engagement have been added to database
       | 1  | app1  | test        | 1      | pending |
   
   And the following engagements exist:
-      | id | app_id | contact_id | coaching_org_id | coach_id | team_number | start_date | student_names       |
-      | 1  | 1      | 1          | 1               | 1        | 1           | 2017-10-01 | fake1, fake2, fake3 |
+      | id | app_id | coach_id | team_number | start_date | student_names       |
+      | 1  | 1      | 1        | 1           | 2017-10-01 | fake1, fake2, fake3 |
+  
+  And the following iterations exist:
+      | id | engagement_id | end_date   | customer_feedback | general_feedback     |
+      | 2  | 1             | 2017-10-26 |                   | this team was great! |
+
+
+  And I'm logged in on the orgs page
 
 # Story ID: 153070134
 Scenario: I can enter general feedback when creating a new iteration
   Given I am on the engagement iterations page for engagement id "1"
-  And I follow "Add iteration..."
-  When I fill in "General Feedback" with "blah blah blah"
+  And I follow "Add Iteration..."
+  When I fill in "General feedback" with "blah blah blah"
   And I press "Save"
   Given I am on the engagement iterations page for engagement id "1"
   Then I should see "General Feedback"
   And I should see "blah blah blah"
+
+# Story ID: 153070134
+Scenario: I can edit general feedback
+  Given I am on the engagement iterations page for engagement id "1"
+  Then I should see "this team was great!"
+  Given I am on the edit engagement iteration page for engagement id "1" and iteration id "2"
+  When I fill in "iteration[general_feedback]" with "this team was terrible"
+  And I press "Save Changes"
+  Given I am on the engagement iterations page for engagement id "1"
+  Then I should see "General Feedback"
+  And I should see "this team was terrible"


### PR DESCRIPTION
I added simple option for user to add "general feedback" instead of "customer feedback" upon creation of new iteration. This is displayed on the iterations index page, and can also be edited.